### PR TITLE
allow baud rate change

### DIFF
--- a/adafruit_espatcommands.py
+++ b/adafruit_espatcommands.py
@@ -11,7 +11,7 @@ class espatcommands:
     TYPE_UDP = "UDP"
     TYPE_SSL = "SSL"
 
-    def __init__(self, uart, baudrate, *, reset_pin=None, debug=False):
+    def __init__(self, uart, unused_baudrate, *, reset_pin=None, debug=False):
         self._uart = uart
         self._reset_pin = reset_pin
         if self._reset_pin:
@@ -24,6 +24,16 @@ class espatcommands:
             if not self.soft_reset():
                 self.hard_reset()
                 self.soft_reset()
+        self.echo(False)
+
+
+
+    @property
+    def baudrate(self):
+        return self._uart.baudrate
+
+    @baudrate.setter
+    def baudrate(self, baudrate):
         if self._uart.baudrate != baudrate:
             at_cmd = "AT+UART_CUR="+str(baudrate)+",8,1,0,0\r\n"
             if self._debug:
@@ -36,7 +46,7 @@ class espatcommands:
             self._uart.reset_input_buffer()
             if not self.sync():
                 raise RuntimeError("Failed to resync after Baudrate change")
-        self.echo(False)
+
 
 
     def request_url(self, url, ssl=False):

--- a/adafruit_espatcommands.py
+++ b/adafruit_espatcommands.py
@@ -24,7 +24,20 @@ class espatcommands:
             if not self.soft_reset():
                 self.hard_reset()
                 self.soft_reset()
+        if self._uart.baudrate != baudrate:
+            at_cmd = "AT+UART_CUR="+str(baudrate)+",8,1,0,0\r\n"
+            if self._debug:
+                print("changing baudrate to: ",baudrate)
+                print("--->",at_cmd)
+            self._uart.write(bytes(at_cmd,'utf-8'))
+            time.sleep(.25)
+            self._uart.baudrate = baudrate
+            time.sleep(.25)
+            self._uart.reset_input_buffer()
+            if not self.sync():
+                raise RuntimeError("Failed to resync after Baudrate change")
         self.echo(False)
+
 
     def request_url(self, url, ssl=False):
         if url.startswith("https://"):

--- a/adafruit_espatcommands.py
+++ b/adafruit_espatcommands.py
@@ -103,11 +103,11 @@ class espatcommands:
         while (time.monotonic() - t) < timeout:
             if self._uart.in_waiting:
                 prompt += self._uart.read(1)
-                if prompt[-1:] == b'>':
+                if prompt[-2:] == b'> ':
                     break
-        if not prompt or ( prompt[-1:] != b'>'):
+        if not prompt or ( prompt[-2:] != b'> '):
             raise RuntimeError("Didn't get data prompt for sending")
-        self._uart.reset_input_buffer()
+#        self._uart.reset_input_buffer()
         self._uart.write(buffer)
         t = time.monotonic()
         response = b''

--- a/adafruit_espatcommands.py
+++ b/adafruit_espatcommands.py
@@ -11,7 +11,7 @@ class espatcommands:
     TYPE_UDP = "UDP"
     TYPE_SSL = "SSL"
 
-    def __init__(self, uart, unused_baudrate, *, reset_pin=None, debug=False):
+    def __init__(self, uart, baudrate, *, reset_pin=None, debug=False):
         self._uart = uart
         self._reset_pin = reset_pin
         if self._reset_pin:
@@ -24,6 +24,7 @@ class espatcommands:
             if not self.soft_reset():
                 self.hard_reset()
                 self.soft_reset()
+        self.baudrate = baudrate
         self.echo(False)
 
 


### PR DESCRIPTION
See if you think this is a good way to do this.
espatcommands  has an input parameter baudrate but it actually does not use it so I use it to allow you to switch the baudrate after it initializes.  At 115200 I am getting a lot of dropped characters. it works much better at 9600 baud!  We can change the baudrate of the ESP8266 or ESP32 permanetly via AT+UART_DEF but this way we can start at the 115200 default and set it if we want to.
If the input baudrate  matches the current baudrate setting, then it does not do anything so you don't have to use this.
